### PR TITLE
Add WebSearch service with environment configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@ai-sdk/google": "^1.1.16",
     "@ai-sdk/openai": "^1.1.13",
     "@ai-sdk/perplexity": "^1.0.1",
+    "@t3-oss/env-core": "^0.13.8",
     "ai": "^4.1.45",
     "effect": "^3.16.7",
     "exa-js": "^1.4.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@ai-sdk/perplexity':
         specifier: ^1.0.1
         version: 1.1.9(zod@3.25.64)
+      '@t3-oss/env-core':
+        specifier: ^0.13.8
+        version: 0.13.8(zod@3.25.64)
       ai:
         specifier: ^4.1.45
         version: 4.3.16(react@19.1.0)(zod@3.25.64)
@@ -242,6 +245,23 @@ packages:
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@t3-oss/env-core@0.13.8':
+    resolution: {integrity: sha512-L1inmpzLQyYu4+Q1DyrXsGJYCXbtXjC4cICw1uAKv0ppYPQv656lhZPU91Qd1VS6SO/bou1/q5ufVzBGbNsUpw==}
+    peerDependencies:
+      arktype: ^2.1.0
+      typescript: '>=5.0.0'
+      valibot: ^1.0.0-beta.7 || ^1.0.0
+      zod: ^3.24.0 || ^4.0.0-beta.0
+    peerDependenciesMeta:
+      arktype:
+        optional: true
+      typescript:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
 
   '@types/diff-match-patch@1.0.36':
     resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
@@ -516,6 +536,10 @@ snapshots:
   '@opentelemetry/api@1.9.0': {}
 
   '@standard-schema/spec@1.0.0': {}
+
+  '@t3-oss/env-core@0.13.8(zod@3.25.64)':
+    optionalDependencies:
+      zod: 3.25.64
 
   '@types/diff-match-patch@1.0.36': {}
 

--- a/src/configs/liveConfig.ts
+++ b/src/configs/liveConfig.ts
@@ -1,0 +1,6 @@
+import { env } from "../env";
+
+export const liveConfig = new Map([
+	['OPENAI_API_KEY', env.OPENAI_API_KEY],
+	['EXA_API_KEY', env.EXA_API_KEY]
+]); 

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,40 @@
+import { createEnv } from "@t3-oss/env-core";
+import { z } from "zod";
+
+export const env = createEnv({
+	server: {
+		OPENAI_API_KEY: z.string().min(1),
+		EXA_API_KEY: z.string().min(1),
+	},
+
+	/**
+	 * The prefix that client-side variables must have. This is enforced both at
+	 * a type-level and at runtime.
+	 */
+	// clientPrefix: "PUBLIC_",
+
+	// client: {
+	// 	PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().min(1),
+	// },
+
+	/**
+	 * What object holds the environment variables at runtime. This is usually
+	 * `process.env` or `import.meta.env`.
+	 */
+	runtimeEnv: process.env,
+
+	/**
+	 * By default, this library will feed the environment variables directly to
+	 * the Zod validator.
+	 *
+	 * This means that if you have an empty string for a value that is supposed
+	 * to be a number (e.g. `PORT=` in a ".env" file), Zod will incorrectly flag
+	 * it as a type mismatch violation. Additionally, if you have an empty string
+	 * for a value that is supposed to be a string with a default value (e.g.
+	 * `DOMAIN=` in an ".env" file), the default value will never be applied.
+	 *
+	 * In order to solve these issues, we recommend that all new projects
+	 * explicitly specify this option as true.
+	 */
+	emptyStringAsUndefined: true,
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,15 @@
 import "dotenv/config";
-import { Console, Effect } from "effect";
-import { Ai } from "./services/Ai";
+import { Effect } from "effect";
 import { runtime } from "./services/runtime";
+import { WebSearch } from "./services/WebSearch";
 
 const foo = Effect.gen(function* () {
-	const { generateTextEffect } = yield* Ai;
-	const { text } = yield* generateTextEffect
+	const { searchWeb } = yield* WebSearch;
+	const res = yield* searchWeb('When is the next season of Mobland ?')
 
-	yield* Console.log('text', text)
+	yield* Effect.log(res)
 
-	return text
+	return res
 
 })
 

--- a/src/services/Ai.ts
+++ b/src/services/Ai.ts
@@ -1,13 +1,8 @@
-import { generateText, generateObject } from "ai"
+import { generateObject } from "ai"
 import { Data, Effect } from "effect"
 import z from "zod"
 import { AiModels } from "./AiModels"
 
-class GenerateTextError extends Data.TaggedError("GenerateTextError")<
-	{
-		data: unknown
-	}
-> { }
 
 class GenerateObjectError extends Data.TaggedError("GenerateTextError")<
 	{
@@ -20,16 +15,6 @@ export class Ai extends Effect.Service<Ai>()(
 	"AiService",
 	{
 		effect: Effect.gen(function* () {
-			const { openai } = yield* AiModels
-
-			const generateTextEffect = Effect.tryPromise({
-				try: () => generateText({
-					model: openai('gpt-4-turbo'),
-					prompt: "What is love?"
-				}),
-				catch: (e) => new GenerateTextError({ data: e })
-			})
-
 			const generateSearchQueries = (query: string, n: number = 3) => Effect.gen(function* () {
 				const { openai } = yield* AiModels;
 				const { object: queries } = yield* Effect.tryPromise({
@@ -48,7 +33,7 @@ export class Ai extends Effect.Service<Ai>()(
 			})
 
 
-			return { generateTextEffect }
+			return { generateSearchQueries }
 		}),
 		dependencies: [AiModels.Default]
 	}

--- a/src/services/WebSearch.ts
+++ b/src/services/WebSearch.ts
@@ -1,14 +1,36 @@
-import { Data, Effect, pipe, Schema } from "effect";
+import { Data, Effect, pipe, Schema, Config } from "effect";
 import Exa from 'exa-js'
+import { env } from "../env";
 
 const WebSearchResultSchema = Schema.Struct({
 	title: Schema.NonEmptyString,
 	url: Schema.NonEmptyString,
-	content: Schema.NonEmptyString
-})
+	text: Schema.NonEmptyString
+}).pipe(
+	Schema.transform(
+		Schema.Struct({
+			title: Schema.NonEmptyString,
+			url: Schema.NonEmptyString,
+			content: Schema.NonEmptyString
+
+		}),
+		{
+			decode: ({ title, url, text }) => ({
+				title,
+				url,
+				content: text
+			}),
+			encode: ({ title, url, content }) => ({
+				title,
+				url,
+				text: content
+			})
+		}
+	)
+)
+
 const webSearchResultDecoder = Schema.decodeUnknown(WebSearchResultSchema)
 
-const exa = new Exa(process.env.EXA_API_KEY)
 
 class WebSearchError extends Data.TaggedError("WebSearchErrr")<
 	{
@@ -27,24 +49,28 @@ export class WebSearch extends Effect.Service<WebSearch>()(
 	"WebSearch",
 	{
 		effect: Effect.gen(function* () {
-			const searchWeb = (query: string) => Effect.gen(function* () {
-				const { results } = yield* Effect.tryPromise({
+			const exaApiKey = yield* Config.string('EXA_API_KEY')
+			const exa = new Exa(exaApiKey)
+
+
+			const searchWeb = (query: string) => pipe(
+				Effect.tryPromise({
 					try: () => exa.searchAndContents(query, {
 						numResults: 1,
-						livecrawl: 'always',
+						livecrawl: 'always'
 					}),
 					catch: (e) => new WebSearchError({ cause: e })
-				})
-
-				const decodedResults = results.map((r) => pipe(
-					webSearchResultDecoder(r),
-					Effect.mapError((error) => new WebSearchResultDecodeError({ cause: error }))
-				))
-
-				return decodedResults
-
-
-			})
+				}),
+				Effect.flatMap(({ results }) =>
+					Effect.all(
+						results.map((r) =>
+							webSearchResultDecoder(r).pipe(
+								Effect.mapError((e) => new WebSearchResultDecodeError({ cause: e }))
+							)
+						)
+					)
+				)
+			)
 
 
 			return {

--- a/src/services/runtime.ts
+++ b/src/services/runtime.ts
@@ -1,10 +1,19 @@
-import { Layer, ManagedRuntime } from "effect";
+import { Layer, ManagedRuntime, ConfigProvider } from "effect";
 import { AiModels } from "./AiModels";
 import { Ai } from "./Ai";
+import { liveConfig } from "../configs/liveConfig";
+import { WebSearch } from "./WebSearch";
+
+const LiveConfigProvider = Layer.setConfigProvider(
+	ConfigProvider.fromMap(liveConfig)
+)
 
 const appLayers = Layer.mergeAll(
 	AiModels.Default,
-	Ai.Default
+	Ai.Default,
+	WebSearch.Default
+).pipe(
+	Layer.provide(LiveConfigProvider)
 )
 
 


### PR DESCRIPTION
## Summary
- Implemented WebSearch service with Exa integration for web searching capabilities
- Added environment variables validation using t3-oss/env-core
- Created configuration system with liveConfig for storing API keys
- Updated runtime to use the new services and configuration
- Modified index.ts to demonstrate WebSearch usage

## Test plan
- Ensure EXA_API_KEY is set in your environment variables
- Run the application to verify that web search works correctly
- Check that error handling properly catches and reports issues

🤖 Generated with [Claude Code](https://claude.ai/code)